### PR TITLE
Fixes CORE Widget on subsite home page. Closes #59

### DIFF
--- a/libs/widgets/core_widget.php
+++ b/libs/widgets/core_widget.php
@@ -38,7 +38,8 @@ class CoreWidget extends Widget {
 
 		if (empty($data['core_id']) && empty($data['core_involvement_id'])) {
 			$metadata = $this->theme->metaToData($post->ID);
-			if (empty($metadata['limit']) && !empty($data['limit']))
+			// If $metadata['limit'] not 0 or a positive integer ignore it
+			if (!($metadata['limit'] === 0 || $metadata['limit'] > 0))
 				$metadata['limit'] = $data['limit'];
 			$data = array_merge($data, $metadata);
 		}


### PR DESCRIPTION
A blank page limit clobbers the site option limit. Here, the Our Latest Posts page has no limit set; rather than make people edit the limit on the page being used as the home page, we'll just make sure that a blank limit can't override a non-blank one. If you set 0 on the home page limit, it will still override the option and display all items.
